### PR TITLE
Update receiver registration for Android 7 compatability

### DIFF
--- a/android/src/main/java/expo/modules/zebrascanner/ExpoZebraScannerModule.kt
+++ b/android/src/main/java/expo/modules/zebrascanner/ExpoZebraScannerModule.kt
@@ -58,10 +58,9 @@ class ExpoZebraScannerModule : Module() {
         filter.addAction(ACTION_BARCODE_SCANNED)
 
         barcodeReceiver = BarcodeReceiver(::sendEvent)
-        activity.registerReceiver(
-          barcodeReceiver, filter, ContextCompat.RECEIVER_EXPORTED
+        ContextCompat.registerReceiver(
+            activity, barcodeReceiver, filter, ContextCompat.RECEIVER_EXPORTED
         )
-
       }
     }
 


### PR DESCRIPTION
We have found that calling `registerReceiver` directly on the activity causes a crash with Android 7 (it complains the method does not exist).

This seems to be resolved by using the [ContextCompat class](https://developer.android.com/reference/androidx/core/content/ContextCompat) instead.

Unfortunately I do not currently have physical access to a device running 7 so cannot test scanning functionality, but this does fix the crash (verified in an emulator), and the library continues to function on my physical device running Android 14.